### PR TITLE
fixes on landing page

### DIFF
--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -3,8 +3,16 @@ import styled from "styled-components";
 import { EgoButton } from "../reusables/Button";
 import { Logo } from "../reusables/Logo";
 import Globe from "../assets/Globe-ego.svg";
+import { NoSelect } from "../reusables/NoSelect";
 
 //styles
+// const NoSelect = styled.div`
+//   user-select: none; /* Standard syntax */
+//   -webkit-user-select: none; /* Chrome, Safari, Opera */
+//   -moz-user-select: none; /* Firefox */
+//   -ms-user-select: none; /* Internet Explorer/Edge */
+// `;
+
 const LandingSection = styled.section`
   overflow: hidden;
   height: 100vh;
@@ -29,6 +37,7 @@ const MiddleSection = styled.div`
   position: relative;
   width: 100%;
   height: 300px;
+  z-index: 1;
 
   @media all and (min-width: 1024px) {
     justify-content: space-around;
@@ -42,6 +51,10 @@ const StyledImage = styled.img`
   top: 55%;
   left: 52%;
   transform: translate(-50%, -50%);
+  /* user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none; */
 
   @media (min-width: 768px) {
     height: 140%;
@@ -60,6 +73,10 @@ const StyledTitle = styled.h1`
   font-size: 240px;
   margin: 0;
   z-index: 1;
+  /* user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none; */
 
   @media (min-width: 768px) {
     font-size: 450px;
@@ -114,7 +131,7 @@ const BottomSection = styled.div`
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  z-index: 3;
+  z-index: 4;
 `;
 const StyledEllipse = styled.div`
   display: flex;
@@ -192,18 +209,22 @@ export const Landing = () => {
   return (
     <LandingSection>
       <TopSection>
-        <Link to="/about">
-          <Logo />
-        </Link>
+        <Logo />
         <SmallEgoButton>
           <Link to="/login">Log in</Link>
         </SmallEgoButton>
       </TopSection>
 
       <MiddleSection>
-        <StyledTitle>e</StyledTitle>
-        <StyledImage src={Globe} alt="globe" />
-        <StyledTitle>o</StyledTitle>
+        <NoSelect>
+          <StyledTitle>e</StyledTitle>{" "}
+        </NoSelect>
+        <NoSelect>
+          <StyledImage src={Globe} alt="globe" />
+        </NoSelect>
+        <NoSelect>
+          <StyledTitle>o</StyledTitle>{" "}
+        </NoSelect>
       </MiddleSection>
 
       <BottomSection>

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -6,13 +6,6 @@ import Globe from "../assets/Globe-ego.svg";
 import { NoSelect } from "../reusables/NoSelect";
 
 //styles
-// const NoSelect = styled.div`
-//   user-select: none; /* Standard syntax */
-//   -webkit-user-select: none; /* Chrome, Safari, Opera */
-//   -moz-user-select: none; /* Firefox */
-//   -ms-user-select: none; /* Internet Explorer/Edge */
-// `;
-
 const LandingSection = styled.section`
   overflow: hidden;
   height: 100vh;
@@ -51,10 +44,6 @@ const StyledImage = styled.img`
   top: 55%;
   left: 52%;
   transform: translate(-50%, -50%);
-  /* user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none; */
 
   @media (min-width: 768px) {
     height: 140%;
@@ -73,10 +62,6 @@ const StyledTitle = styled.h1`
   font-size: 240px;
   margin: 0;
   z-index: 1;
-  /* user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none; */
 
   @media (min-width: 768px) {
     font-size: 450px;

--- a/frontend/src/reusables/NoSelect.jsx
+++ b/frontend/src/reusables/NoSelect.jsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 
 export const NoSelect = styled.div`
-  user-select: none; /* Standard syntax */
-  -webkit-user-select: none; /* Chrome, Safari, Opera */
-  -moz-user-select: none; /* Firefox */
-  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
 `;

--- a/frontend/src/reusables/NoSelect.jsx
+++ b/frontend/src/reusables/NoSelect.jsx
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+export const NoSelect = styled.div`
+  user-select: none; /* Standard syntax */
+  -webkit-user-select: none; /* Chrome, Safari, Opera */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+`;


### PR DESCRIPTION
Fixed the three things we discussed: 
- took the logo link away (link to about was unnecessary there), we have "about us" at the bottom that links to the about page
- fixed overlap
- added a NoSelect-Component, so that the big ego part in the middle cannot be selected anymore (blue boxes) not visible anymore. 
- NoSelect-Component can be used on other parts too